### PR TITLE
Prerequisite fixes

### DIFF
--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -107,6 +107,38 @@ bool BuildingClassFake::_Can_Have_Rally_Point()
 }
 
 
+// Comparison function for sorting sidebar icons (BuildTypes)
+// Author: Rampastring
+int __cdecl BuildType_Comparison(const void* p1, const void* p2)
+{
+    SidebarClass::StripClass::BuildType* bt1 = (SidebarClass::StripClass::BuildType*)p1;
+    SidebarClass::StripClass::BuildType* bt2 = (SidebarClass::StripClass::BuildType*)p2;
+
+    if (bt1->BuildableType == bt2->BuildableType)
+        return bt1->BuildableID - bt2->BuildableID;
+
+    if (bt1->BuildableType == RTTI_INFANTRYTYPE)
+        return -1;
+
+    if (bt2->BuildableType == RTTI_INFANTRYTYPE)
+        return 1;
+
+    if (bt1->BuildableType == RTTI_UNITTYPE)
+        return -1;
+
+    if (bt2->BuildableType == RTTI_UNITTYPE)
+        return 1;
+
+    if (bt1->BuildableType == RTTI_AIRCRAFTTYPE)
+        return -1;
+
+    if (bt2->BuildableType == RTTI_AIRCRAFTTYPE)
+        return 1;
+
+    return 0;
+}
+
+
 /**
  *  Makes the game check whether you can actually build the object before adding it to the sidebar,
  *  preventing grayed out cameos (except for build limited types)
@@ -129,6 +161,7 @@ void BuildingClassFake::_Update_Buildables()
                     Map.Add(RTTI_AIRCRAFTTYPE, i);
                 }
             }
+            qsort(&Map.Column[1].Buildables, Map.Column[1].BuildableCount, sizeof(SidebarClass::StripClass::BuildType), &BuildType_Comparison);
             break;
 
         case RTTI_BUILDINGTYPE:
@@ -139,6 +172,7 @@ void BuildingClassFake::_Update_Buildables()
                     Map.Add(RTTI_BUILDINGTYPE, i);
                 }
             }
+            qsort(&Map.Column[0].Buildables, Map.Column[0].BuildableCount, sizeof(SidebarClass::StripClass::BuildType), &BuildType_Comparison);
             break;
 
         case RTTI_INFANTRYTYPE:
@@ -149,6 +183,7 @@ void BuildingClassFake::_Update_Buildables()
                     Map.Add(RTTI_INFANTRYTYPE, i);
                 }
             }
+            qsort(&Map.Column[1].Buildables, Map.Column[1].BuildableCount, sizeof(SidebarClass::StripClass::BuildType), &BuildType_Comparison);
             break;
 
         case RTTI_UNITTYPE:
@@ -159,6 +194,7 @@ void BuildingClassFake::_Update_Buildables()
                     Map.Add(RTTI_UNITTYPE, i);
                 }
             }
+            qsort(&Map.Column[1].Buildables, Map.Column[1].BuildableCount, sizeof(SidebarClass::StripClass::BuildType), &BuildType_Comparison);
             break;
 
         default:

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -107,6 +107,14 @@ bool BuildingClassFake::_Can_Have_Rally_Point()
 }
 
 
+/**
+ *  Makes the game check whether you can actually build the object before adding it to the sidebar,
+ *  preventing grayed out cameos (except for build limited types)
+ *
+ *  This reimplements the entire BuildingClass::Update_Buildables() function
+ *
+ *  @author: ZivDero
+ */
 void BuildingClassFake::_Update_Buildables()
 {
     if (House == PlayerPtr && !IsInLimbo && IsDiscoveredByPlayer && IsPowerOn)

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -107,8 +107,11 @@ bool BuildingClassFake::_Can_Have_Rally_Point()
 }
 
 
-// Comparison function for sorting sidebar icons (BuildTypes)
-// Author: Rampastring
+/**
+ *  Comparison function for sorting sidebar icons (BuildTypes)
+ *
+ *  @author: Rampastring
+ */
 int __cdecl BuildType_Comparison(const void* p1, const void* p2)
 {
     SidebarClass::StripClass::BuildType* bt1 = (SidebarClass::StripClass::BuildType*)p1;

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -66,6 +66,7 @@
 #include "fatal.h"
 #include "asserthandler.h"
 #include "debughandler.h"
+#include "infantrytype.h"
 
 #include "hooker.h"
 #include "hooker_macros.h"
@@ -82,6 +83,7 @@ static class BuildingClassFake final : public BuildingClass
 {
 public:
     bool _Can_Have_Rally_Point();
+    void _Update_Buildables();
 };
 
 
@@ -102,6 +104,59 @@ bool BuildingClassFake::_Can_Have_Rally_Point()
         return true;
 
     return false;
+}
+
+
+void BuildingClassFake::_Update_Buildables()
+{
+    if (House == PlayerPtr && !IsInLimbo && IsDiscoveredByPlayer && IsPowerOn)
+    {
+        switch (Class->ToBuild)
+        {
+        case RTTI_AIRCRAFTTYPE:
+            for (int i = 0; i < AircraftTypes.Count(); i++)
+            {
+                if (PlayerPtr->Can_Build(AircraftTypes[i], false, true) && AircraftTypes[i]->Who_Can_Build_Me(true, true, true, PlayerPtr) != nullptr)
+                {
+                    Map.Add(RTTI_AIRCRAFTTYPE, i);
+                }
+            }
+            break;
+
+        case RTTI_BUILDINGTYPE:
+            for (int i = 0; i < BuildingTypes.Count(); i++)
+            {
+                if (PlayerPtr->Can_Build(BuildingTypes[i], false, true) && BuildingTypes[i]->Who_Can_Build_Me(true, true, true, PlayerPtr) != nullptr)
+                {
+                    Map.Add(RTTI_BUILDINGTYPE, i);
+                }
+            }
+            break;
+
+        case RTTI_INFANTRYTYPE:
+            for (int i = 0; i < InfantryTypes.Count(); i++)
+            {
+                if (PlayerPtr->Can_Build(InfantryTypes[i], false, true) && InfantryTypes[i]->Who_Can_Build_Me(true, true, true, PlayerPtr) != nullptr)
+                {
+                    Map.Add(RTTI_INFANTRYTYPE, i);
+                }
+            }
+            break;
+
+        case RTTI_UNITTYPE:
+            for (int i = 0; i < UnitTypes.Count(); i++)
+            {
+                if (PlayerPtr->Can_Build(UnitTypes[i], false, true) && UnitTypes[i]->Who_Can_Build_Me(true, true, true, PlayerPtr) != nullptr)
+                {
+                    Map.Add(RTTI_UNITTYPE, i);
+                }
+            }
+            break;
+
+        default:
+            break;
+        }
+    }
 }
 
 
@@ -2006,4 +2061,6 @@ void BuildingClassExtension_Hooks()
     Patch_Jump(0x0042EF9D, &_BuildingClass_What_Action_Allow_Rally_Point_For_Naval_Yard_Patch);
 
     Patch_Jump(0x0042C624, &_BuildingClass_Assign_Target_No_Deconstruction_With_Null_UndeploysInto);
+
+    Patch_Jump(0x0042D9A0, &BuildingClassFake::_Update_Buildables);
 }

--- a/src/extensions/factory/factoryext_hooks.cpp
+++ b/src/extensions/factory/factoryext_hooks.cpp
@@ -55,6 +55,12 @@ public:
 };
 
 
+/**
+ *  Checks if this factory should abandon construction because the objects
+ *	in the queue are no longer available to build
+ *
+ *  @author: ZivDero
+ */
 void FactoryClassFake::_Verify_Can_Build()
 {
 	const TechnoClass* producing_object = Get_Object();

--- a/src/extensions/factory/factoryext_hooks.cpp
+++ b/src/extensions/factory/factoryext_hooks.cpp
@@ -63,20 +63,19 @@ void FactoryClassFake::_Verify_Can_Build()
 		return;
 
 	const TechnoTypeClass* producing_type = producing_object->Techno_Type_Class();
+	const RTTIType type = producing_type->Kind_Of();
 
-	if (producing_type == nullptr)
-		return;
-
+	// Check the thing we're currently building separately - it needs special handling
 	if (!House->Can_Build(producing_type, false, false))
 	{
 		Abandon();
 
 		if (House == PlayerPtr)
 		{
-			const RTTIType type = producing_type->Kind_Of();
 			const int column = type == RTTI_BUILDING || type == RTTI_BUILDINGTYPE ? 0 : 1;
 			Map.Column[column].Flag_To_Redraw();
 
+			// Remove map placement if we're doing that
 			if (type == RTTI_BUILDING || type == RTTI_BUILDINGTYPE)
 			{
 				Map.PendingObject = nullptr;
@@ -87,6 +86,7 @@ void FactoryClassFake::_Verify_Can_Build()
 		}
 	}
 
+	// Now make sure there are no invalid objects in the queue
 	for (int i = 0; i < QueuedObjects.Count(); i++)
 	{
 		if (!House->Can_Build(QueuedObjects[i], false, false))
@@ -96,6 +96,7 @@ void FactoryClassFake::_Verify_Can_Build()
 		}
 	}
 
+	House->Update_Factories(type);
     Resume_Queue();
 }
 

--- a/src/extensions/factory/factoryext_hooks.cpp
+++ b/src/extensions/factory/factoryext_hooks.cpp
@@ -185,18 +185,16 @@ DECLARE_PATCH(_FactoryClass_AI_Abandon_If_Cant_Build)
 {
     GET_REGISTER_STATIC(FactoryClassFake*, this_ptr, ecx);
 
-    _asm push esi
-
     this_ptr->_Verify_Can_Build();
 
-    _asm
-    {
-        pop esi
-        mov al, [esi + 5Ch]
-        test al, al
+    // Stolen bytes / code.
+    if (this_ptr->IsSuspended) {
+        // Factory is suspended, exit from function.
+        JMP(0x00496FA3);
     }
-
-    JMP_REG(ebx, 0x00496EAC);
+    
+    // Continue factory AI logic.
+    JMP(0x00496EB2);
 }
 
 

--- a/src/extensions/factory/factoryext_hooks.cpp
+++ b/src/extensions/factory/factoryext_hooks.cpp
@@ -51,59 +51,59 @@
 static class FactoryClassFake final : public FactoryClass
 {
 public:
-	void _Verify_Can_Build();
+    void _Verify_Can_Build();
 };
 
 
 /**
  *  Checks if this factory should abandon construction because the objects
- *	in the queue are no longer available to build
+ *    in the queue are no longer available to build
  *
  *  @author: ZivDero
  */
 void FactoryClassFake::_Verify_Can_Build()
 {
-	const TechnoClass* producing_object = Get_Object();
+    const TechnoClass* producing_object = Get_Object();
 
-	if (producing_object == nullptr)
-		return;
+    if (producing_object == nullptr)
+        return;
 
-	const TechnoTypeClass* producing_type = producing_object->Techno_Type_Class();
-	const RTTIType type = producing_type->Kind_Of();
+    const TechnoTypeClass* producing_type = producing_object->Techno_Type_Class();
+    const RTTIType type = producing_type->Kind_Of();
 
-	// Check the thing we're currently building separately - it needs special handling
-	if (!House->Can_Build(producing_type, false, false))
-	{
-		Abandon();
+    // Check the thing we're currently building separately - it needs special handling
+    if (!House->Can_Build(producing_type, false, false))
+    {
+        Abandon();
 
-		if (House == PlayerPtr)
-		{
-			const int column = type == RTTI_BUILDING || type == RTTI_BUILDINGTYPE ? 0 : 1;
-			Map.Column[column].Flag_To_Redraw();
+        if (House == PlayerPtr)
+        {
+            const int column = type == RTTI_BUILDING || type == RTTI_BUILDINGTYPE ? 0 : 1;
+            Map.Column[column].Flag_To_Redraw();
 
-			// Remove map placement if we're doing that
-			if (type == RTTI_BUILDING || type == RTTI_BUILDINGTYPE)
-			{
-				Map.PendingObject = nullptr;
-				Map.PendingObjectPtr = nullptr;
-				Map.PendingHouse = HOUSE_NONE;
-				Map.Set_Cursor_Shape(nullptr);
-			}
-		}
-	}
+            // Remove map placement if we're doing that
+            if (type == RTTI_BUILDING || type == RTTI_BUILDINGTYPE)
+            {
+                Map.PendingObject = nullptr;
+                Map.PendingObjectPtr = nullptr;
+                Map.PendingHouse = HOUSE_NONE;
+                Map.Set_Cursor_Shape(nullptr);
+            }
+        }
+    }
 
-	// Now make sure there are no invalid objects in the queue
-	for (int i = 0; i < QueuedObjects.Count(); i++)
-	{
-		if (!House->Can_Build(QueuedObjects[i], false, false))
-		{
-			Remove_From_Queue(*QueuedObjects[i]);
-			i--;
-		}
-	}
+    // Now make sure there are no invalid objects in the queue
+    for (int i = 0; i < QueuedObjects.Count(); i++)
+    {
+        if (!House->Can_Build(QueuedObjects[i], false, false))
+        {
+            Remove_From_Queue(*QueuedObjects[i]);
+            i--;
+        }
+    }
 
-	House->Update_Factories(type);
-	Resume_Queue();
+    House->Update_Factories(type);
+    Resume_Queue();
 }
 
 
@@ -114,59 +114,59 @@ void FactoryClassFake::_Verify_Can_Build()
  */
 DECLARE_PATCH(_FactoryClass_AI_InstantBuild_Patch)
 {
-	GET_REGISTER_STATIC(FactoryClass *, this_ptr, esi);
+    GET_REGISTER_STATIC(FactoryClass *, this_ptr, esi);
 
-	if (Vinifera_DeveloperMode) {
+    if (Vinifera_DeveloperMode) {
 
-		/**
-		 *  If AIInstantBuild is toggled on, make sure this is a non-human AI house.
-		 */
-		if (Vinifera_Developer_AIInstantBuild
-			&& !this_ptr->House->Is_Human_Control() && this_ptr->House != PlayerPtr) {
+        /**
+         *  If AIInstantBuild is toggled on, make sure this is a non-human AI house.
+         */
+        if (Vinifera_Developer_AIInstantBuild
+            && !this_ptr->House->Is_Human_Control() && this_ptr->House != PlayerPtr) {
 
-			this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
-			goto production_completed;
-		}
+            this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
+            goto production_completed;
+        }
 
-		/**
-		 *  If InstantBuild is toggled on, make sure the local player is a human house.
-		 */
-		if (Vinifera_Developer_InstantBuild
-			&& this_ptr->House->Is_Human_Control() && this_ptr->House == PlayerPtr) {
+        /**
+         *  If InstantBuild is toggled on, make sure the local player is a human house.
+         */
+        if (Vinifera_Developer_InstantBuild
+            && this_ptr->House->Is_Human_Control() && this_ptr->House == PlayerPtr) {
 
-			this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
-			goto production_completed;
-		}
+            this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
+            goto production_completed;
+        }
 
-		/**
-		 *  If the AI has taken control of the player house, it needs a special
-		 *  case to handle the "player" instant build mode.
-		 */
-		if (Vinifera_Developer_InstantBuild) {
-			if (Vinifera_Developer_AIControl && this_ptr->House == PlayerPtr) {
+        /**
+         *  If the AI has taken control of the player house, it needs a special
+         *  case to handle the "player" instant build mode.
+         */
+        if (Vinifera_Developer_InstantBuild) {
+            if (Vinifera_Developer_AIControl && this_ptr->House == PlayerPtr) {
 
-				this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
-				goto production_completed;
-			}
-		}
+                this_ptr->StageClass::Set_Stage(FactoryClass::STEP_COUNT);
+                goto production_completed;
+            }
+        }
 
-	}
+    }
 
-	/**
-	 *  Stolen bytes/code.
-	 */
-	if (this_ptr->StageClass::Fetch_Stage() == FactoryClass::STEP_COUNT) {
-		goto production_completed;
-	}
+    /**
+     *  Stolen bytes/code.
+     */
+    if (this_ptr->StageClass::Fetch_Stage() == FactoryClass::STEP_COUNT) {
+        goto production_completed;
+    }
 
 function_return:
-	JMP(0x00496FA3);
+    JMP(0x00496FA3);
 
     /**
      *  Production Completed, then suspend further production.
      */
 production_completed:
-	JMP(0x00496F73);
+    JMP(0x00496F73);
 }
 
 
@@ -178,20 +178,20 @@ production_completed:
  */
 DECLARE_PATCH(_Factory_Class_AI_Abandon_If_Cant_Build)
 {
-	GET_REGISTER_STATIC(FactoryClassFake*, this_ptr, ecx);
+    GET_REGISTER_STATIC(FactoryClassFake*, this_ptr, ecx);
 
     _asm push esi
 
-	this_ptr->_Verify_Can_Build();
+    this_ptr->_Verify_Can_Build();
 
-	_asm
-	{
-		pop esi
-		mov al, [esi + 5Ch]
-		test al, al
-	}
+    _asm
+    {
+        pop esi
+        mov al, [esi + 5Ch]
+        test al, al
+    }
 
-	JMP_REG(ebx, 0x00496EAC);
+    JMP_REG(ebx, 0x00496EAC);
 }
 
 
@@ -200,6 +200,6 @@ DECLARE_PATCH(_Factory_Class_AI_Abandon_If_Cant_Build)
  */
 void FactoryClassExtension_Hooks()
 {
-	Patch_Jump(0x00496F6D, &_FactoryClass_AI_InstantBuild_Patch);
-	Patch_Jump(0x00496EA7, &_Factory_Class_AI_Abandon_If_Cant_Build);
+    Patch_Jump(0x00496F6D, &_FactoryClass_AI_InstantBuild_Patch);
+    Patch_Jump(0x00496EA7, &_Factory_Class_AI_Abandon_If_Cant_Build);
 }

--- a/src/extensions/factory/factoryext_hooks.cpp
+++ b/src/extensions/factory/factoryext_hooks.cpp
@@ -103,7 +103,7 @@ void FactoryClassFake::_Verify_Can_Build()
 	}
 
 	House->Update_Factories(type);
-    Resume_Queue();
+	Resume_Queue();
 }
 
 

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -1681,6 +1681,6 @@ void HouseClassExtension_Hooks()
     Patch_Jump(0x004CB6C1, &_HouseClass_Enable_SWs_Check_For_Building_Power);
     Patch_Jump(0x004C0F87, &_HouseClass_AI_Raise_Money_Fix_Memory_Corruption);
     Patch_Jump(0x004BE218, &_HouseClass_Begin_Production_Check_For_Unallowed_Buildables);
-    Patch_Jump(0x004BC023, 0x004BC102); // Skip checking the owner of the MCV when building buildings
+    Patch_Jump(0x004BC023, 0x004BC102); // Skip checking the owner of the MCV when building buildings in HouseClass::Can_Build
     // Patch_Jump(0x004C10E8, &_HouseClass_AI_Building_Intercept);
 }

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -1660,12 +1660,6 @@ DECLARE_PATCH(_HouseClass_Begin_Production_Check_For_Unallowed_Buildables)
 }
 
 
-DECLARE_PATCH(_HouseClass_Remove_ConYard_Owner_Check)
-{
-    JMP(0x004BC102);
-}
-
-
 /**
  *  Main function for patching the hooks.
  */
@@ -1687,6 +1681,6 @@ void HouseClassExtension_Hooks()
     Patch_Jump(0x004CB6C1, &_HouseClass_Enable_SWs_Check_For_Building_Power);
     Patch_Jump(0x004C0F87, &_HouseClass_AI_Raise_Money_Fix_Memory_Corruption);
     Patch_Jump(0x004BE218, &_HouseClass_Begin_Production_Check_For_Unallowed_Buildables);
-    Patch_Jump(0x004BC023, &_HouseClass_Remove_ConYard_Owner_Check);
+    Patch_Jump(0x004BC023, 0x004BC102); // Skip checking the owner of the MCV when building buildings
     // Patch_Jump(0x004C10E8, &_HouseClass_AI_Building_Intercept);
 }

--- a/src/extensions/house/houseext_hooks.cpp
+++ b/src/extensions/house/houseext_hooks.cpp
@@ -1660,6 +1660,12 @@ DECLARE_PATCH(_HouseClass_Begin_Production_Check_For_Unallowed_Buildables)
 }
 
 
+DECLARE_PATCH(_HouseClass_Remove_ConYard_Owner_Check)
+{
+    JMP(0x004BC102);
+}
+
+
 /**
  *  Main function for patching the hooks.
  */
@@ -1681,5 +1687,6 @@ void HouseClassExtension_Hooks()
     Patch_Jump(0x004CB6C1, &_HouseClass_Enable_SWs_Check_For_Building_Power);
     Patch_Jump(0x004C0F87, &_HouseClass_AI_Raise_Money_Fix_Memory_Corruption);
     Patch_Jump(0x004BE218, &_HouseClass_Begin_Production_Check_For_Unallowed_Buildables);
+    Patch_Jump(0x004BC023, &_HouseClass_Remove_ConYard_Owner_Check);
     // Patch_Jump(0x004C10E8, &_HouseClass_AI_Building_Intercept);
 }

--- a/src/extensions/objecttype/objecttypeext_hooks.cpp
+++ b/src/extensions/objecttype/objecttypeext_hooks.cpp
@@ -228,4 +228,5 @@ void ObjectTypeClassExtension_Hooks()
     Patch_Jump(0x00588D00, &ObjectTypeClassExt::_Assign_Theater_Name);
     Patch_Jump(0x0058891D, &_ObjectTypeClass_Load_Theater_Art_Assign_Theater_Name_Theater_Patch);
     Patch_Jump(0x00587B9C, &_ObjectTypeClass__Who_Can_Build_Me_Naval_Yard_Patch);
+    Patch_Jump(0x00587BFA, 0x00587C0B); // Skip checking the owner of the MCV when building buildings in ObjectTypeClass::Who_Can_Build_Me
 }

--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -210,6 +210,6 @@ void SidebarClassExtension_Hooks()
     // Change jle to jl to allow rendering tooltips that are exactly as wide as the sidebar
     Patch_Byte(0x0044E605 + 1, 0x8C);
 
-    // Patch the argument to the HouseClass::Can_Build in SidebarClass::StripClass::Recalc so that prerequisites are checked
+    // Patch the argument to HouseClass::Can_Build in SidebarClass::StripClass::Recalc so that prerequisites are checked
     Patch_Byte(0x005F5762, false);
 }

--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -209,4 +209,7 @@ void SidebarClassExtension_Hooks()
 
     // Change jle to jl to allow rendering tooltips that are exactly as wide as the sidebar
     Patch_Byte(0x0044E605 + 1, 0x8C);
+
+    // Patch the argument to the HouseClass::Can_Build in SidebarClass::StripClass::Recalc so that things get removed from the sidebar
+    Patch_Byte(0x005F5762, false);
 }

--- a/src/extensions/sidebar/sidebarext_hooks.cpp
+++ b/src/extensions/sidebar/sidebarext_hooks.cpp
@@ -210,6 +210,6 @@ void SidebarClassExtension_Hooks()
     // Change jle to jl to allow rendering tooltips that are exactly as wide as the sidebar
     Patch_Byte(0x0044E605 + 1, 0x8C);
 
-    // Patch the argument to the HouseClass::Can_Build in SidebarClass::StripClass::Recalc so that things get removed from the sidebar
+    // Patch the argument to the HouseClass::Can_Build in SidebarClass::StripClass::Recalc so that prerequisites are checked
     Patch_Byte(0x005F5762, false);
 }


### PR DESCRIPTION
- Buildables are now removed from the sidebar when you lose their prerequisites
- You no longer need a construction yard built by the same house to build buildings owned by that house
- Things that you wouldn't be able to build no longer show up as darkened cameos (except for build limited things)