### PR TITLE
Allow Units with JumpJet locomotion to take damage in air

### DIFF
--- a/src/extensions/bullet/bulletext_hooks.cpp
+++ b/src/extensions/bullet/bulletext_hooks.cpp
@@ -742,6 +742,7 @@ DECLARE_PATCH(_BulletClass_AI_Intercept)
 
 /**
  *  Halves the distance from the explosion to the unit for units in air.
+ *  The game already performs this for Aircraft, In_Air() was added in YR.
  *
  *  @author: ZivDero
  */


### PR DESCRIPTION
Previously, JumpJet locomotion units wouldn't take damage in air because they weren't contained in cells, and there wasn't a special check for them. This makes them damagable.