### PR TITLE
Fix merge bugs

### DIFF
--- a/src/extensions/aircraft/aircraftext_hooks.cpp
+++ b/src/extensions/aircraft/aircraftext_hooks.cpp
@@ -944,7 +944,7 @@ void AdvAI_Aircraft_Maintenance(AircraftClass* aircraft)
                 BuildingClass* cellbldg = Map[aircraft->PositionCell].Cell_Building();
                 if (cellbldg == nullptr) {
                     for (int i = 0; i < aircraft->Class->Dock.Count(); i++) {
-                        BuildingClass* dockingbay = aircraft->Find_Docking_Bay(aircraft->Class->Dock[i], false, false);
+                        BuildingClass* dockingbay = aircraft->Find_Docking_Bay(aircraft->Class->Dock[i], false, true);
                         if (dockingbay != nullptr && aircraft->Transmit_Message(RADIO_HELLO, dockingbay) == RADIO_ROGER) {
                             aircraft->Assign_Destination(dockingbay);
                             aircraft->Assign_Mission(MISSION_ENTER);

--- a/src/extensions/building/buildingext_hooks.cpp
+++ b/src/extensions/building/buildingext_hooks.cpp
@@ -1067,7 +1067,14 @@ void BuildingClassExt::_Draw_Overlays(const Point2D& coord, const Rect& rect)
                 int delay = Options.Normalize_Delay(14) / 4;
                 delay = std::max(delay, 2);
 
-                Draw_Shape(*LogicalSurface, *MouseDrawer, WrenchShape, 6 * (Frame % delay) / (delay - 1), xy, rect, SHAPE_ALPHA | SHAPE_WIN_REL | SHAPE_CENTER);
+                int draw_frame;
+                if (Extension::Fetch(House)->IsPauseRepairs && House->Available_Money() < Class->Repair_Step()) {
+                    draw_frame = RuleExtension->PausedRepairsFrame;
+                } else {
+                    draw_frame = 6 * (Frame % delay) / (delay - 1);
+                }
+
+                Draw_Shape(*LogicalSurface, *MouseDrawer, WrenchShape, draw_frame, xy, rect, SHAPE_ALPHA | SHAPE_WIN_REL | SHAPE_CENTER);
             }
         }
 
@@ -2660,40 +2667,6 @@ DEFINE_HOOK(0x00435A38, _BuildingClass_Repair_AI_Pause_Repairs_Patch, 7)
     }
 
     return 0;
-}
-
-/*
- *  Reimplements part of BuildingClass::Draw_Overlays where a building determines the wrench frame to use when drawing during repairs.
- *  When the building's repairs are paused, the game draws a specific wrench frame to signal that the repairs are paused.
- *
- *  @author: JoyfulShush
- */
-DEFINE_HOOK(0x004288E1, _BuildingClass_Draw_Overlays_Wrench_Shape_Patch, 0)
-{
-    GET(BuildingClass*, this_ptr, ESI);
-    GET(int, frame, ECX);
-    GET(Point2D*, point, EDI);
-    GET(Rect*, rect, EBP);
-
-    HouseClassExtension* houseext = Extension::Fetch(this_ptr->House);
-
-    int draw_frame;
-    if (this_ptr->House->Is_Human_Player() && houseext->IsPauseRepairs && this_ptr->House->Available_Money() < this_ptr->Class->Repair_Step()) {
-        draw_frame = RuleExtension->PausedRepairsFrame;
-    } else {
-        draw_frame = 6 * (Frame % frame) / (frame - 1);
-    }
-
-    Draw_Shape(*LogicalSurface,
-        *MouseDrawer,
-        (ShapeSet const*)BuildingClass::WrenchShape, 
-        draw_frame,
-        *point,
-        *rect,
-        ShapeFlags_Type(SHAPE_CENTER | SHAPE_WIN_REL | SHAPE_ALPHA)        
-    );
-
-    return 0x00428925;
 }
 
 /**

--- a/src/extensions/foot/footext_hooks.cpp
+++ b/src/extensions/foot/footext_hooks.cpp
@@ -799,68 +799,6 @@ bool FootClassExt::_Limbo()
 }
 
 /**
- *  Patches FootClass::Do_MISSION_GUARD_AREA during the archive target check.
- *  This overrides the distance that a unit can move away before a area-guarding unit will still to chase it,
- *  as well as allowing units to keep engaging a target before abandoning it and returning to the unit it is guarding.
- *  When not provided, falls back to the original game logic.
- *
- *  @author: JoyfulShush
- */
-DEFINE_HOOK(0x004A2B90, _FootClass_Do_MISSION_GUARD_AREA_Escort_Distance_Patch, 6)
-{
-    GET(FootClass*, this_ptr, ESI);
-    TechnoTypeClassExtension* ext = Extension::Fetch(this_ptr->TClass);
-
-    enum {
-        TarComCheck = 0x004A2BDD,
-        GoToArchiveTarget = 0x004A2BBE,
-        ApproachTarcomTarget = 0x004A2C25
-    };
-
-    if (this_ptr->ArchiveTarget == nullptr) {
-        return TarComCheck;
-    }
-    
-    if (this_ptr->TarCom != nullptr) {
-        int abandon_target_escort_range = -1;
-        if (ext->AbandonTargetEscortRange > 0) {
-            abandon_target_escort_range = ext->AbandonTargetEscortRange;
-        }
-
-        if (abandon_target_escort_range <= 0 && RuleExtension->AbandonTargetEscortRange > 0) {
-            abandon_target_escort_range = RuleExtension->AbandonTargetEscortRange;
-        }
-
-        if (abandon_target_escort_range > 0) {
-            if (this_ptr->Distance_To(this_ptr->ArchiveTarget) >= abandon_target_escort_range) {
-                return GoToArchiveTarget;
-            }
-        }
-
-        return ApproachTarcomTarget;
-    }
-    
-    int escort_range = -1;
-    if (ext->EscortRange > 0) {
-        escort_range = ext->EscortRange;
-    }
-
-    if (escort_range <= 0 && RuleExtension->EscortRange > 0) {
-        escort_range = RuleExtension->EscortRange;
-    }
-
-    if (escort_range > 0) {
-        if (this_ptr->Distance_To(this_ptr->ArchiveTarget) >= escort_range) {
-            return GoToArchiveTarget;
-        }
-
-        return TarComCheck;
-    }
-    
-    return 0;
-}
-
-/**
  *  Patches FootClass::Active_Click_With inside the 'ACTION_ATTACK_SUPPORT' case.
  *  Makes healing units (negative damage) prefer to guard other units instead of themselves.
  *  Healing units will guard other combatants, if any, and will assign themselves to the unit closest to them.
@@ -906,24 +844,6 @@ DEFINE_HOOK(0x004A3518, _FootClass_Active_Click_With_Attack_Support_Patch, 0)
 
     return 0x004A2F95;
 }
-
-/**
- *  Patches FootClass::Do_MISSION_GUARD_AREA inside the 'this->TarCom' case, where the unit is assigned to approach its tarcom target.
- *  Clears the current destination, which made object-specific Area Guarding units have to go back to their guard object
- *  between each time a tarcom target is acquired, as Approach_Target in vanilla code only kicked in
- *  after the unit started moving towards its guard object.
- *
- *  @author: JoyfulShush
- */
-DEFINE_HOOK(0x004A2C25, _FootClass_Do_MISSION_GUARD_AREA_Approach_Target_Patch, 10)
-{
-    GET(FootClass*, this_ptr, ESI);
-
-    this_ptr->Assign_Destination(nullptr);
-
-    return 0;
-}
-
 
 // Copy of Target_Something_Nearby that does not ignore ThreatTypes other than the range specifiers.
 bool Respectable_Target_Something_Nearby(FootClassExt* foot, Coord & coord, ThreatType threat)
@@ -1279,6 +1199,8 @@ DEFINE_HOOK(0x004A58A8, _FootClass_AI_Hook, 0)
 */
 int FootClassExt::_Do_MISSION_GUARD_AREA()
 {
+    TechnoTypeClassExtension* technotype_ext = Extension::Fetch(TClass);
+
     if (!House->Is_Human_Player() && NavQueue.Count() > 0 && NavCom == nullptr && NavQueue[0] == ArchiveTarget) {
         AbstractClass* first = NavQueue[0];
         if (first != nullptr) {
@@ -1343,6 +1265,24 @@ int FootClassExt::_Do_MISSION_GUARD_AREA()
             Assign_Target(nullptr);
         }
 
+        int escort_range = -1;
+        if (technotype_ext->EscortRange > 0) {
+            escort_range = technotype_ext->EscortRange;
+        }
+
+        if (escort_range <= 0) {
+            if (RuleExtension->EscortRange > 0) {
+                escort_range = RuleExtension->EscortRange;
+            }
+         }
+
+        if (escort_range > 0) {
+            if (Distance_To(ArchiveTarget) >= escort_range) {
+                Assign_Target(nullptr);
+                Assign_Destination(ArchiveTarget);
+            }
+        }
+
         if (!IsFiring && NavCom == nullptr && Distance(ArchiveTarget) > maxrange && 
             (!RuleExtension->AdvancedAIAreaGuard || TarCom == nullptr))
         {
@@ -1370,7 +1310,25 @@ int FootClassExt::_Do_MISSION_GUARD_AREA()
             }
         }
         else {
-            Approach_Target();
+            int abandon_target_escort_range = -1;
+            if (technotype_ext->AbandonTargetEscortRange > 0) {
+                abandon_target_escort_range = technotype_ext->AbandonTargetEscortRange;
+            }
+
+            if (abandon_target_escort_range <= 0) {
+                if (RuleExtension->AbandonTargetEscortRange > 0) {
+                    abandon_target_escort_range = RuleExtension->AbandonTargetEscortRange;
+                }
+            }
+
+            if (abandon_target_escort_range > 0) {
+                if (Distance_To(ArchiveTarget) >= abandon_target_escort_range) {
+                    Assign_Target(nullptr);
+                    Assign_Destination(ArchiveTarget);
+                }
+            } else {                
+                Approach_Target();
+            }
         }
     }
 

--- a/src/extensions/infantry/infantryext_hooks.cpp
+++ b/src/extensions/infantry/infantryext_hooks.cpp
@@ -858,7 +858,7 @@ DEFINE_HOOK(0x004D71CF, _Infantry_Class_What_Action_Medic_Toggle_Select_Patch, 9
 {
     GET(ActionType, action, EBX);
 
-    if (action == ACTION_TOGGLE_SELECT) {
+    if (action == ACTION_TOGGLE_SELECT || action == ACTION_GUARD_AREA || action == ACTION_MOVE) {
         return 0x004D76F9;
     }
 


### PR DESCRIPTION
Fix bugs that occurred due to DTA's Vinifera implementation differences when merging from TSC Vinifera:

* Fix an issue where Adv AI aircraft stopped rearming on docks after attacking.
* Fix an issue where the game would crash if a healer unit (e.g. medics) was selected and player would put their cursor over another unit while in area-guard mode.
* Fix an issue where escort and abandon escort did not work due to reimplementation.
* Fix an issue where paused repair frames did not work due to reimplementation.